### PR TITLE
add potential shift in dvtot, preparing for fix potential (lgcscf) calculations

### DIFF
--- a/src/calculator.f90
+++ b/src/calculator.f90
@@ -270,6 +270,8 @@ CONTAINS
         END IF
         !
         CALL aux%destroy()
+        IF (main%setup%lsmearedions)  &
+            main%dvtot%of_r = main%dvtot%of_r + main%environment_ions%potential_shift
         !
         CALL write_cube(main%dvtot, main%system_ions, local_verbose)
         !

--- a/src/main.f90
+++ b/src/main.f90
@@ -194,7 +194,7 @@ CONTAINS
     !! only once per pw.x execution.
     !!
     !------------------------------------------------------------------------------------
-    SUBROUTINE init_environ_base(this, nat, ntyp, ityp, zv, label, number, weight)
+    SUBROUTINE init_environ_base(this, nat, ntyp, ityp, zv, label, number, weight, lgcscf)
         !--------------------------------------------------------------------------------
         !
         IMPLICIT NONE
@@ -205,11 +205,16 @@ CONTAINS
         CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: label(ntyp)
         INTEGER, OPTIONAL, INTENT(IN) :: number(ntyp)
         REAL(DP), OPTIONAL, INTENT(IN) :: weight(ntyp)
+        LOGICAL  :: lgcscf 
         !
         CLASS(environ_main), INTENT(INOUT) :: this
         !
+        CHARACTER(LEN=80) :: routine = 'init_environ_base'
+        !
         !--------------------------------------------------------------------------------
         !
+        if (lgcscf == .true.  .and. env_electrolyte_ntyp<2) &
+            CALL io%error(routine, "Set env_electrolyte_ntyp >= 2 when lgcscf == .true. ", 1)
         CALL this%create()
         !
         CALL this%init_potential()
@@ -1144,12 +1149,12 @@ CONTAINS
         !
         IF (.NOT. io%lnode) RETURN
         !
-        IF (this%setup%lsmearedions) &
-            WRITE (io%unit, 1100) this%environment_ions%potential_shift * RYTOEV
-        !
-1100    FORMAT(/, 5(' '), &
-                "the potential shift due to the Gaussian-smeared nuclei is ", &
-                F10.4, " ev")
+!        IF (this%setup%lsmearedions) &
+!            WRITE (io%unit, 1100) this%environment_ions%potential_shift * RYTOEV
+!        !
+!1100    FORMAT(/, 5(' '), &
+!                "the potential shift due to the Gaussian-smeared nuclei is ", &
+!                F10.4, " ev")
         !
         !--------------------------------------------------------------------------------
     END SUBROUTINE print_environ_potential_shift


### PR DESCRIPTION
Add potential shift in dvtot to make the electro-static potential in vacuum(solvent) is zero. 

Add a logic test to make sure that people have env_electrolyte_ntyp>=2 when have lgcscf == .true.. This should run with a new Quantum ESPRESSO which allows lgcscf with Quantum ENVIRON later. 