### PR TITLE
fixed environ cards input

### DIFF
--- a/src/input.f90
+++ b/src/input.f90
@@ -230,17 +230,23 @@ CONTAINS
         CALL env_read_line(local_unit, input_line, end_of_file=tend)
         !
         IF (.NOT. tend) THEN
-            !
-            READ (input_line, *) card ! store card title only in 'card'
-            !
             input_line = env_uppercase(input_line) ! force uppercase
+            READ (input_line, *) card ! store card title only in 'card'
             !
             IF (TRIM(card) == 'EXTERNAL_CHARGES') THEN
                 CALL card_external_charges(local_unit, input_line)
+            ELSE IF (TRIM(card) == 'DIELECTRIC_REGIONS') THEN
+                CALL card_dielectric_regions(local_unit, input_line)
             ELSE IF (io%lnode) THEN
                 CALL io%warning("card "//TRIM(input_line)//" ignored", 1001)
             END IF
-            !
+        END IF
+        !
+        CALL env_read_line(local_unit, input_line, end_of_file=tend)
+        !
+        IF (.NOT. tend) THEN
+            input_line = env_uppercase(input_line)! force uppercase 
+            READ (input_line, *) card ! store card title only in 'card'
             IF (TRIM(card) == 'DIELECTRIC_REGIONS') THEN
                 CALL card_dielectric_regions(local_unit, input_line)
             ELSE IF (io%lnode) THEN


### PR DESCRIPTION
## What
Fixed `environ_read_cards` to support using `EXTERNAL_CHARGES` and `DIELECTRIC_REGIONS` together, which was previously broken. Input lines are now uppercased before being saved to the card, making unit parsing case-insensitive.

## Why
Using both `EXTERNAL_CHARGES` and `DIELECTRIC_REGIONS` in the same input was impossible.  Additionally, unit keywords were case-sensitive.

Closes: https://groups.google.com/g/quantum-environ-users/c/PMEynymN1jI

## Changes
- Fixed conflict between `EXTERNAL_CHARGES` and `DIELECTRIC_REGIONS` in `environ_read_cards`
- Force uppercase on `input_line` before saving to card to normalize unit parsing

